### PR TITLE
Button, Navbar 컴포넌트 생성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "15.5.3",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "react-icons": "^5.5.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1324,17 +1325,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz",
-      "integrity": "sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.1.tgz",
+      "integrity": "sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.44.0",
-        "@typescript-eslint/type-utils": "8.44.0",
-        "@typescript-eslint/utils": "8.44.0",
-        "@typescript-eslint/visitor-keys": "8.44.0",
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/type-utils": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -1348,7 +1349,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.44.0",
+        "@typescript-eslint/parser": "^8.44.1",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -1364,16 +1365,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.0.tgz",
-      "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.1.tgz",
+      "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.44.0",
-        "@typescript-eslint/types": "8.44.0",
-        "@typescript-eslint/typescript-estree": "8.44.0",
-        "@typescript-eslint/visitor-keys": "8.44.0",
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1389,14 +1390,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.0.tgz",
-      "integrity": "sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
+      "integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.44.0",
-        "@typescript-eslint/types": "^8.44.0",
+        "@typescript-eslint/tsconfig-utils": "^8.44.1",
+        "@typescript-eslint/types": "^8.44.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1411,14 +1412,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz",
-      "integrity": "sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
+      "integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.44.0",
-        "@typescript-eslint/visitor-keys": "8.44.0"
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1429,9 +1430,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz",
-      "integrity": "sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
+      "integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1446,15 +1447,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.0.tgz",
-      "integrity": "sha512-9cwsoSxJ8Sak67Be/hD2RNt/fsqmWnNE1iHohG8lxqLSNY8xNfyY7wloo5zpW3Nu9hxVgURevqfcH6vvKCt6yg==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.1.tgz",
+      "integrity": "sha512-KdEerZqHWXsRNKjF9NYswNISnFzXfXNDfPxoTh7tqohU/PRIbwTmsjGK6V9/RTYWau7NZvfo52lgVk+sJh0K3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.44.0",
-        "@typescript-eslint/typescript-estree": "8.44.0",
-        "@typescript-eslint/utils": "8.44.0",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -1471,9 +1472,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz",
-      "integrity": "sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
+      "integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1485,16 +1486,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz",
-      "integrity": "sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
+      "integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.44.0",
-        "@typescript-eslint/tsconfig-utils": "8.44.0",
-        "@typescript-eslint/types": "8.44.0",
-        "@typescript-eslint/visitor-keys": "8.44.0",
+        "@typescript-eslint/project-service": "8.44.1",
+        "@typescript-eslint/tsconfig-utils": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1570,16 +1571,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.0.tgz",
-      "integrity": "sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.1.tgz",
+      "integrity": "sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.44.0",
-        "@typescript-eslint/types": "8.44.0",
-        "@typescript-eslint/typescript-estree": "8.44.0"
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1594,13 +1595,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz",
-      "integrity": "sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
+      "integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.44.0",
+        "@typescript-eslint/types": "8.44.1",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -5138,6 +5139,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -11,20 +11,21 @@
   "dependencies": {
     "next": "15.5.3",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "react-icons": "^5.5.0"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.1.13",
-    "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.13",
     "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4.1.13",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.5.3",
+    "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
+    "tailwindcss": "^4.1.13",
     "typescript": "^5"
   }
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -4,4 +4,6 @@
 export default {
   plugins: ["prettier-plugin-tailwindcss"],
   tailwindStylesheet: "./app/globals.css",
+  printWidth: 100,
+  tabWidth: 2,
 };

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,8 +5,21 @@
 
 @theme {
   /* color */
-  --color-primary: oklch(0.704 0.157 276.4);
+  --color-primary: oklch(0.704 0.216 275.7);
+  --color-primary-hover: oklch(0.64 0.23 275.7);
 
+  --color-secondary: oklch(0.8 0.05 250);
+  --color-secondary-hover: oklch(0.75 0.06 250);
+
+  --color-success: oklch(0.78 0.2 140);
+  --color-success-hover: oklch(0.72 0.23 140);
+
+  --color-danger: oklch(0.68 0.25 27);
+  --color-danger-hover: oklch(0.62 0.28 27);
+
+  --color-outlined: oklch(0.88 0.03 250);
+  --color-outlined-hover: oklch(0.83 0.04 250);
+  
   /* spacing */
   --spacing-xs: 0.125rem; /* 2 */
   --spacing-sm: 0.25rem; /*  4*/
@@ -27,55 +40,35 @@
   --radius-4xl: 2rem; /* 32 */
 
   /* text */
-  --text-xs: 0.75rem;
-  --text-xs--line-height: calc(1 / 0.75);
-  --text-sm: 0.875rem;
-  --text-sm--line-height: calc(1.25 / 0.875);
-  --text-base: 1rem;
-  --text-base--line-height: calc(1.5 / 1);
-  --text-lg: 1.125rem;
-  --text-lg--line-height: calc(1.75 / 1.125);
-  --text-xl: 1.25rem;
-  --text-xl--line-height: calc(1.75 / 1.25);
-  --text-2xl: 1.5rem;
-  --text-2xl--line-height: calc(2 / 1.5);
-  --text-3xl: 1.875rem;
-  --text-3xl--line-height: calc(2.25 / 1.875);
-  --text-4xl: 2.25rem;
-  --text-4xl--line-height: calc(2.5 / 2.25);
-  --text-5xl: 3rem;
-  --text-5xl--line-height: 1;
-  --text-6xl: 3.75rem;
-  --text-6xl--line-height: 1;
-  --text-7xl: 4.5rem;
-  --text-7xl--line-height: 1;
-  --text-8xl: 6rem;
-  --text-8xl--line-height: 1;
-  --text-9xl: 8rem;
-  --text-9xl--line-height: 1;
+  /* Heading styles */
+  --text-h1:  2.25rem; /* 36px */
+  --text-h1--line-height: 2.75rem; /* 44px */
+  --text-h2: 1.875rem; /* 30px */
+  --text-h2--line-height: 2.25rem; /* 36px */
+  --text-h3: 1.5rem; /* 24px */
+  --text-h3--line-height: 2rem; /* 32px */
+
+  /* Body styles */
+  --text-body-lg: 1rem; /* 16px */
+  --text-body--line-height: 1.5rem; /* 24px */
+
+  --text-body-md: 0.875rem; /* 14px */
+  --text-body-md--line-height: 1.25rem; /* 20px */
+
+  --text-body-sm: 0.75rem; /* 12px */
+  --text-body-sm--line-height: 1rem; /* 16px */
+
+  /* Caption */
+  --text-caption:  0.625rem; /* 10px */
+  --text-caption--line-height: 1rem; /* 16px */
 }
 
-html,
 body {
   min-width: 300px;
   min-height: 600px;
   width: 100dvw;
   height: 100dvh;
   overflow-x: hidden;
-}
-
-body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-* {
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
 }

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,52 +1,59 @@
-'use client';
+"use client";
 
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
-type Variant = 'none' | 'primary' | 'secondary' | 'success' | 'danger' | 'outlined';
+type Variant =
+  | "none"
+  | "primary"
+  | "secondary"
+  | "success"
+  | "danger"
+  | "outlined";
 
-type Size = 'sm' | 'md' | 'lg' | 'full';
+type Size = "sm" | "md" | "lg" | "full";
 
-type Rounded = 'sm' | 'md' | 'lg' | 'full';
+type Rounded = "sm" | "md" | "lg" | "full";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
   variant: Variant;
   size: Size;
   rounded: Rounded;
-  className?:string;
-};
+  className?: string;
+}
 
 export default function Button({
   children,
   variant,
-  size = 'md',
-  rounded = 'lg',
-  className = '',
+  size = "md",
+  rounded = "lg",
+  className = "",
   ...props
-}:ButtonProps) {
-  const baseClasses = 'text-center w-fit text-sm transition-colors duration-200';
+}: ButtonProps) {
+  const baseClasses =
+    "text-center w-fit text-sm transition-colors duration-200";
 
   const variantClasses = {
     none: "",
-    primary: 'bg-primary text-white hover:bg-primary-hover',
-    secondary: 'bg-secondary hover:bg-secondary-hover',
-    success: 'bg-success text-white hover:bg-success-hover',
-    danger: 'bg-danger text-white hover:bg-danger-hover',
-    outlined: 'border border-outlined hover:bg-outlined-hover',
+    primary: "bg-primary text-white hover:bg-primary-hover",
+    secondary: "bg-secondary hover:bg-secondary-hover",
+    success: "bg-success text-white hover:bg-success-hover",
+    danger: "bg-danger text-white hover:bg-danger-hover",
+    outlined: "border border-outlined hover:bg-outlined-hover",
   };
 
   const sizeClasses = {
-    sm: 'px-3',
-    md: 'px-4',
-    lg: 'px-6',
-    full: 'px-auto w-full'
+    sm: "px-3",
+    md: "px-4",
+    lg: "px-6",
+    full: "px-auto w-full",
   };
 
   const roundedClasses = {
-    sm: 'rounded-sm',
-    md: 'rounded-md',
-    lg: 'rounded-lg',
-    full: 'rounded-full',
+    sm: "rounded-sm",
+    md: "rounded-md",
+    lg: "rounded-lg",
+    full: "rounded-full",
   };
 
   const classes = `
@@ -61,4 +68,4 @@ export default function Button({
       {children}
     </button>
   );
-};
+}

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+type Variant = 'none' | 'primary' | 'secondary' | 'success' | 'danger' | 'outlined';
+
+type Size = 'sm' | 'md' | 'lg' | 'full';
+
+type Rounded = 'sm' | 'md' | 'lg' | 'full';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+  variant: Variant;
+  size: Size;
+  rounded: Rounded;
+  className?:string;
+};
+
+export default function Button({
+  children,
+  variant,
+  size = 'md',
+  rounded = 'lg',
+  className = '',
+  ...props
+}:ButtonProps) {
+  const baseClasses = 'text-center w-fit text-sm transition-colors duration-200';
+
+  const variantClasses = {
+    none: "",
+    primary: 'bg-primary text-white hover:bg-primary-hover',
+    secondary: 'bg-secondary hover:bg-secondary-hover',
+    success: 'bg-success text-white hover:bg-success-hover',
+    danger: 'bg-danger text-white hover:bg-danger-hover',
+    outlined: 'border border-outlined hover:bg-outlined-hover',
+  };
+
+  const sizeClasses = {
+    sm: 'px-3',
+    md: 'px-4',
+    lg: 'px-6',
+    full: 'px-auto w-full'
+  };
+
+  const roundedClasses = {
+    sm: 'rounded-sm',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    full: 'rounded-full',
+  };
+
+  const classes = `
+    ${baseClasses} 
+    ${variantClasses[variant]} 
+    ${sizeClasses[size]} 
+    ${roundedClasses[rounded]} 
+    ${className}`;
+
+  return (
+    <button className={classes} {...props}>
+      {children}
+    </button>
+  );
+};

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -1,85 +1,83 @@
 "use client";
 
+/**component */
 import Link from "next/link";
-import { TbAppleFilled } from "react-icons/tb";
+
+/**library */
 import { usePathname } from "next/navigation";
+import { ComponentType } from "react";
+
+/** icons */
+import type { IconType } from "react-icons/lib";
+import { ImPlay, ImPencil, ImHome, ImCog, ImCloud } from "react-icons/im";
+
+interface IconWrapperProps {
+  icon: ComponentType<{ className?: string; size?: number }>; // 이 타입에 대해서 제대로 모르는거 아닐까..??
+  size: number;
+  isActive?: boolean;
+}
+
+function IconWrapper({ icon: Icon, size, isActive }: IconWrapperProps) {
+  const iconClass = `aspect-square transition-colors duration-200 ${
+    isActive
+      ? "text-primary group-hover:text-primary-hover"
+      : "text-secondary group-hover:text-secondary-hover"
+  }`;
+  return <Icon size={size} className={iconClass} />;
+}
 
 type Page = {
   name: string;
   href: string;
-  icon: (isActive: boolean) => React.ReactNode;
+  icon: IconType;
 }[];
 
 export default function Navbar() {
   const pathname = usePathname();
-  const iconClass = "h-[35px] aspect-square";
+
   const pages: Page = [
     {
       name: "HOME",
       href: "/",
-      icon: (isActive) => (
-        <TbAppleFilled
-          size={35}
-          className={`${iconClass} ${isActive ? "text-primary hover:text-primary-hover" : "text-secondary"}`}
-        />
-      ),
+      icon: ImHome,
     },
     {
       name: "SQUARE",
       href: "/square",
-      icon: (isActive) => (
-        <TbAppleFilled
-          size={35}
-          className={`${iconClass} ${isActive ? "text-primary hover:text-primary-hover" : "text-secondary"}`}
-        />
-      ),
+      icon: ImCloud,
     },
     {
       name: "DREAM",
       href: "/dream/new",
-      icon: (isActive) => (
-        <TbAppleFilled
-          size={35}
-          className={`${iconClass} ${isActive ? "text-primary hover:text-primary-hover" : "text-secondary"}`}
-        />
-      ),
+      icon: ImPencil,
     },
     {
       name: "STREAM",
       href: "/stream",
-      icon: (isActive) => (
-        <TbAppleFilled
-          size={35}
-          className={`${iconClass} ${isActive ? "text-primary hover:text-primary-hover" : "text-secondary"}`}
-        />
-      ),
+      icon: ImPlay,
     },
     {
       name: "SETTINGS",
       href: "/settings",
-      icon: (isActive) => (
-        <TbAppleFilled
-          size={35}
-          className={`${iconClass} ${isActive ? "text-primary hover:text-primary-hover" : "text-secondary"}`}
-        />
-      ),
+      icon: ImCog,
     },
   ];
+
   return (
-    <nav className="flex h-[80px] justify-between gap-x-3 bg-white p-5 text-xs font-bold">
+    <nav className="flex h-[70px] justify-between gap-x-3 bg-white p-1 px-5 text-xs">
       {pages.map((page) => {
         const isActive = pathname == page.href;
         return (
           <Link
             href={page.href}
             key={page.name}
-            className={`group flex flex-col items-center justify-center`}
+            className="group flex flex-col items-center justify-center"
           >
-            {page.icon(isActive)}
+            <IconWrapper icon={page.icon} size={25} isActive={isActive} />
             <p
               className={
                 isActive
-                  ? `text-primary group-hover:text-primary-hover`
+                  ? "text-primary group-hover:text-primary-hover"
                   : "text-secondary group-hover:text-secondary-hover"
               }
             >

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import Link from "next/link";
+import { TbAppleFilled } from "react-icons/tb";
+import { usePathname } from "next/navigation";
+
+type Page = {
+  name: string;
+  href: string;
+  icon: (isActive: boolean) => React.ReactNode;
+}[];
+
+export default function Navbar() {
+  const pathname = usePathname();
+  const iconClass = "h-[35px] aspect-square";
+  const pages: Page = [
+    {
+      name: "HOME",
+      href: "/",
+      icon: (isActive) => (
+        <TbAppleFilled
+          size={35}
+          className={`${iconClass} ${isActive ? "text-primary hover:text-primary-hover" : "text-secondary"}`}
+        />
+      ),
+    },
+    {
+      name: "SQUARE",
+      href: "/square",
+      icon: (isActive) => (
+        <TbAppleFilled
+          size={35}
+          className={`${iconClass} ${isActive ? "text-primary hover:text-primary-hover" : "text-secondary"}`}
+        />
+      ),
+    },
+    {
+      name: "DREAM",
+      href: "/dream/new",
+      icon: (isActive) => (
+        <TbAppleFilled
+          size={35}
+          className={`${iconClass} ${isActive ? "text-primary hover:text-primary-hover" : "text-secondary"}`}
+        />
+      ),
+    },
+    {
+      name: "STREAM",
+      href: "/stream",
+      icon: (isActive) => (
+        <TbAppleFilled
+          size={35}
+          className={`${iconClass} ${isActive ? "text-primary hover:text-primary-hover" : "text-secondary"}`}
+        />
+      ),
+    },
+    {
+      name: "SETTINGS",
+      href: "/settings",
+      icon: (isActive) => (
+        <TbAppleFilled
+          size={35}
+          className={`${iconClass} ${isActive ? "text-primary hover:text-primary-hover" : "text-secondary"}`}
+        />
+      ),
+    },
+  ];
+  return (
+    <nav className="flex h-[80px] justify-between gap-x-3 bg-white p-5 text-xs font-bold">
+      {pages.map((page) => {
+        const isActive = pathname == page.href;
+        return (
+          <Link
+            href={page.href}
+            key={page.name}
+            className={`group flex flex-col items-center justify-center`}
+          >
+            {page.icon(isActive)}
+            <p
+              className={
+                isActive
+                  ? `text-primary group-hover:text-primary-hover`
+                  : "text-secondary group-hover:text-secondary-hover"
+              }
+            >
+              {page.name}
+            </p>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
### `Navbar.tsx`
- 각 메뉴의 icon에 적용되는 스타일이 중복되어 이를 간소화하기 위해 `IconWrapper`를 생성하여 코드 수정 => 이후에 컴포넌트로 분리할 예정
- icon과 메뉴명에 hover css가 따로 적용됨 => `group` 을 사용하여 둘 중 하나의 노드에 hover되어도 스타일이 동시에 적용되도록 함.


### `Button.tsx`
- 현재 size와 rounded의 type을 sm, md, lg, full로만 설정해두었음. 이후에 수정 가능성 있음
- 해당 컴포넌트를 감싸는 상위 요소에 `flex-col` 적용 시 블록 요소처럼 전체 너비를 차지 => `w-fit`으로 자식 요소의 크기에 맞추어 너비 자동으로 설정하도록 함