### PR TITLE
feat: login segment UI 구현

### DIFF
--- a/src/app/(public)/login/_components/OAuthList.tsx
+++ b/src/app/(public)/login/_components/OAuthList.tsx
@@ -1,0 +1,20 @@
+// component
+import Button from "@/components/common/Button";
+import { IoChatbubble } from "react-icons/io5";
+
+export default function OAuthList() {
+  return (
+    <div className="flex h-[300px] flex-col justify-center">
+      <Button
+        type="button"
+        variant="none"
+        size="full"
+        rounded="md"
+        className="flex h-[50px] items-center rounded-lg bg-yellow-300 p-2"
+      >
+        <IoChatbubble size={30} />
+        <p className="flex-1 text-base font-bold">카카오 로그인</p>
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -1,3 +1,16 @@
+import OAuthList from "./_components/OAuthList";
+
 export default function LoginPage() {
-  return <div></div>;
+  return (
+    <div className="p-2xl flex h-full w-full flex-col">
+      <div className="gap-lg flex flex-1 flex-col items-end justify-center font-bold text-white">
+        <h1 className="text-h1">DREA-MONG</h1>
+        <div className="gap-md flex flex-col items-end justify-center">
+          <p className="text-subtitle">꿈의 비밀을 통해</p>
+          <p className="text-subtitle">자신을 발견해보세요.</p>
+        </div>
+      </div>
+      <OAuthList />
+    </div>
+  );
 }


### PR DESCRIPTION
## 로그인 페이지 구현

### `OAuthList.tsx`
- 현재 카카오만 구현되어 있음
- UI의 경우 margin과 padding 중 padding을 기준으로 UI를 구현하고 있음.
- 로그인 로직 연결 후 컴포넌트 분리 고려