### PR TITLE
flex-1 및 overflow-y-scroll 적용

### DIFF
--- a/src/app/(protected)/(main)/_components/DateSelector.tsx
+++ b/src/app/(protected)/(main)/_components/DateSelector.tsx
@@ -26,9 +26,9 @@ export default function DateSelector({ year, month, handleMonth, handleYear }: D
   }, [month]);
 
   return (
-    <div className={"flex flex-col gap-4"}>
+    <div className={"h-fit space-y-4"}>
       {/* 년도 선택 */}
-      <div className="flex items-center justify-center gap-12 text-xl">
+      <div className="flex items-center justify-center gap-x-12 text-xl">
         <button onClick={() => handleYear(-1)}>{"<"}</button>
         <p className="text-lg">{year}</p>
         <button onClick={() => handleYear(1)}>{">"}</button>
@@ -44,17 +44,18 @@ export default function DateSelector({ year, month, handleMonth, handleYear }: D
         slideToClickedSlide={true}
         className="mySwiper w-full"
       >
-        {Array.from({ length: 12 }).map((_, i) => (
-          <SwiperSlide key={i} onClick={() => handleMonth(i + 1)} className="">
-            <div
-              className={`flex items-center justify-center rounded-lg py-3 ${month == i + 1 ? "bg-violet-500" : "border border-solid border-slate-200"}`}
-            >
-              <p className={`text-sm ${i + 1 == month ? "text-white" : "text-slate-600"}`}>
-                {i + 1}월
-              </p>
-            </div>
-          </SwiperSlide>
-        ))}
+        {Array.from({ length: 12 }).map((_, i) => {
+          const isSelectedMonth = month == i + 1;
+          return (
+            <SwiperSlide key={i} onClick={() => handleMonth(i + 1)}>
+              <div
+                className={`flex items-center justify-center rounded-lg py-3 ${isSelectedMonth ? "bg-violet-500 text-white" : "border border-solid border-slate-200 text-slate-600"}`}
+              >
+                <p>{i + 1}월</p>
+              </div>
+            </SwiperSlide>
+          );
+        })}
       </Swiper>
     </div>
   );

--- a/src/app/(protected)/(main)/_components/DreamList/index.tsx
+++ b/src/app/(protected)/(main)/_components/DreamList/index.tsx
@@ -13,7 +13,7 @@ interface DreamListProps {
 export default function DreamList({ dreams }: DreamListProps) {
   const handleClick = () => {};
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-scroll">
+    <div className="hide-scrollbar flex min-h-0 flex-1 flex-col gap-1 overflow-y-scroll">
       {dreams.map((dream) => (
         <DreamItem key={dream.dreamId} dream={dream} handleClick={handleClick} />
       ))}

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,3 +1,4 @@
+// component
 import Navbar from "@/components/common/Navbar";
 
 export default function AppLayout({
@@ -6,11 +7,13 @@ export default function AppLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className={"flex h-full w-full flex-col"}>
-      {/* main*/}
-      <div className={`flex min-h-0 flex-1 flex-col`}>{children}</div>
+    <>
+      {/* main */}
+      <div className="flex min-h-0 flex-1 flex-col">{children}</div>
       {/* Navbar */}
       <Navbar />
-    </div>
+    </>
   );
 }
+
+// TODO: flex-1은 직속 부모가 flex일 때 정상 동작한다. (+ min-h-0)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -71,3 +71,11 @@ body {
   width: 100dvw;
   height: 100dvh;
 }
+
+.hide-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+.hide-scrollbar {
+  -ms-overflow-style: none; /* IE, Edge */
+  scrollbar-width: none; /* Firefox */
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,12 +66,8 @@
   --text-caption--line-height: 1rem; /* 16px */
 }
 
+html,
 body {
-  min-width: 300px;
-  min-height: 600px;
   width: 100dvw;
   height: 100dvh;
-  overflow-x: hidden;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,12 +17,8 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body>
-        <div className="flex h-full w-full justify-center">
-          <div
-            className={
-              "h-full w-full min-w-[400px] max-w-[500px] bg-[url(/background.svg)] bg-cover bg-center"
-            }
-          >
+        <div className="h-full w-full bg-slate-500">
+          <div className="mx-auto flex h-full min-h-[600px] w-full min-w-[300px] max-w-[500px] flex-col bg-[url(/background.svg)]">
             {children}
           </div>
         </div>

--- a/src/components/layout/BottomSheetLayout.tsx
+++ b/src/components/layout/BottomSheetLayout.tsx
@@ -4,7 +4,7 @@ type BottomSheetLayoutProps = Readonly<{
 
 export default function BottomSheetLayout({ children }: BottomSheetLayoutProps) {
   return (
-    <div className={"flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto rounded-t-xl bg-white p-4"}>
+    <div className={"p-lg gap-md flex min-h-0 flex-1 flex-col rounded-t-xl bg-white"}>
       {children}
     </div>
   );


### PR DESCRIPTION
### `DateSelector.tsx`
- 선택된 월에 따라 div와 p 태그에 유사한 방식으로 class가 적용되고 있었음
=> `isSelectedMonth` 플래그를 활용하는 방식으로 로직을 개선함

### `flex-1` 및 `overflow-y-scroll` 적용
- 모바일 환경 기준으로 제작되어 부분적으로 스크롤이 필요한 경우가 많음
- Next.js의 layout을 사용해 컴포넌트를 분리하는 과정에서, 자식 노드가 부모 노드보다 커질 경우 `flex-1`이 정상적으로 동작하지 않아 레이아웃이 깨지는 문제 발생함
=> flex-1이 올바르게 동작하기 위해서는 부모 노드의 display가 flex여야 하며, 동일 레벨 노드들의 크기가 명확히 정의되어야 함을 확인, 이를 고려하여 전반적인 CSS를 수정함