### PR TITLE
`stream` UI 생성

### DIFF
--- a/src/app/(protected)/stream/[streamId]/page.tsx
+++ b/src/app/(protected)/stream/[streamId]/page.tsx
@@ -1,0 +1,43 @@
+import Image from "next/image";
+import HeaderBar from "@/components/bar/HeaderBar";
+import BottomSheetLayout from "@/components/layout/BottomSheetLayout";
+
+export default function StreamDetailPage() {
+  return (
+    <>
+      <div className="p-md space-y-md flex flex-col">
+        <HeaderBar />
+        <div className="relative h-[200px] w-full opacity-80">
+          <Image
+            src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e"
+            alt="stream"
+            fill
+            className="rounded-lg"
+          />
+        </div>
+        <div className="gap-x-sm flex w-full text-white">
+          <p className="flex-1 truncate">
+            이것은 음악방송 테스트입니다. 이것은 음악방송 테스트입니다.
+          </p>
+          <p>0명 시청중</p>
+        </div>
+      </div>
+      <BottomSheetLayout isDarkMode={true} className="px-0 py-0">
+        <div className="hide-scrollbar p-md flex-1 overflow-y-scroll">
+          {Array.from({ length: 50 }).map((e, idx) => (
+            <div
+              key={idx}
+              className={`text-white ${!((idx * 3) % 7 > 2) ? "text-right" : "text-left"}`}
+            >
+              <p className="font-semibold">별명</p>
+              <p className="">채팅내용이 들어갈 곳입니다.</p>
+            </div>
+          ))}
+        </div>
+        <textarea className="rouded-lg" />
+      </BottomSheetLayout>
+    </>
+  );
+}
+
+// TODO: 초기 설정은 내가 들어온 순간부터의 대화를 저장하는 것으로!

--- a/src/app/(protected)/stream/layout.tsx
+++ b/src/app/(protected)/stream/layout.tsx
@@ -1,0 +1,7 @@
+export default function SquareLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <div className={"flex h-full flex-col bg-black/20"}>{children}</div>;
+}

--- a/src/app/(protected)/stream/page.tsx
+++ b/src/app/(protected)/stream/page.tsx
@@ -1,0 +1,30 @@
+// component
+import Image from "next/image";
+import Link from "next/link";
+
+export default function StreamPage() {
+  return (
+    <div className="hide-scrollbar space-y-md p-lg mt-[30px] flex-1 overflow-y-scroll">
+      {Array.from({ length: 10 }).map((e, idx) => (
+        <Link
+          href={`/stream/${idx}`}
+          key={idx}
+          className="p-md space-y-sm block h-[250px] w-full rounded-lg bg-black"
+        >
+          <div className="relative h-[200px] w-full opacity-80">
+            <Image
+              src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e"
+              alt="stream"
+              fill
+              className="rounded-lg"
+            />
+          </div>
+          <div className="gap-x-lg flex w-full text-white">
+            <p className="flex-1 truncate">다음은 stream 페이지 테스트를 위한 제목입니다.</p>
+            <p>0명 시청중</p>
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/components/layout/BottomSheetLayout.tsx
+++ b/src/components/layout/BottomSheetLayout.tsx
@@ -1,11 +1,29 @@
-type BottomSheetLayoutProps = Readonly<{
-  children: React.ReactNode;
-}>;
+"use client";
 
-export default function BottomSheetLayout({ children }: BottomSheetLayoutProps) {
+// type
+import { HTMLAttributes, ReactNode } from "react";
+
+interface BottomSheetLayoutProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  isDarkMode?: boolean;
+}
+
+export default function BottomSheetLayout({
+  children,
+  className,
+  isDarkMode = false,
+  ...rest
+}: BottomSheetLayoutProps) {
   return (
-    <div className={"p-lg gap-md flex min-h-0 flex-1 flex-col rounded-t-xl bg-white"}>
+    <div
+      className={`p-lg gap-md flex min-h-0 flex-1 flex-col rounded-t-xl ${
+        isDarkMode ? "bg-gray-800 text-white" : "bg-white"
+      } ${className ?? ""}`}
+      {...rest}
+    >
       {children}
     </div>
   );
 }
+
+// TODO: type 정의 이후에 다시 고민해보기


### PR DESCRIPTION
### `stream`
- 컴포넌트 재사용을 위해 `BottomSheetLayout`에 커스텀 props 적용 (interface 중심으로 통일하고자 함)
- `truncate`를 사용하여 제목이 생략되도록 함