### PR TITLE
feat: server-fetcher 적용하여 API 연동 및 컴포넌트 수정

### DIFF
--- a/src/app/(protected)/(main)/_components/DreamItem.tsx
+++ b/src/app/(protected)/(main)/_components/DreamItem.tsx
@@ -2,13 +2,13 @@
 import Image from "next/image";
 
 // types
-import { Dream } from "@/types/dream";
+import { MyDreamSummary } from "@/types";
 
 // lib&util
 import { formatDate } from "@/utils/formatter";
 
 interface DreamItemProps {
-  dream: Dream;
+  dream: MyDreamSummary;
   handleClick: () => void;
 }
 

--- a/src/app/(protected)/(main)/_components/DreamList.tsx
+++ b/src/app/(protected)/(main)/_components/DreamList.tsx
@@ -4,17 +4,17 @@
 import DreamItem from "./DreamItem";
 
 // types
-import { Dream } from "@/types/dream";
+import { MyDreamList } from "@/types/dream";
 
 interface DreamListProps {
-  dreams: Dream[];
+  dreamList: MyDreamList;
 }
 
-export default function DreamList({ dreams }: DreamListProps) {
+export default function DreamList({ dreamList }: DreamListProps) {
   const handleClick = () => {};
   return (
     <div className="hide-scrollbar flex min-h-0 flex-1 flex-col gap-1 overflow-y-scroll">
-      {dreams.map((dream) => (
+      {dreamList.map((dream) => (
         <DreamItem key={dream.dreamId} dream={dream} handleClick={handleClick} />
       ))}
     </div>

--- a/src/app/(protected)/(main)/_components/MainClientComponent.tsx
+++ b/src/app/(protected)/(main)/_components/MainClientComponent.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+// library
+import { useState } from "react";
+
+// component
+import DateSelector from "./DateSelector";
+import DreamList from "./DreamList";
+
+// hooks
+import { useYearMonth } from "@/hooks/useYearMonth";
+
+// type
+import { MyDreamList } from "@/types/dream";
+
+interface MainClientComponentProps {
+  initialDreamList: MyDreamList;
+}
+
+export default function MainClientComponent({ initialDreamList }: MainClientComponentProps) {
+  console.log(initialDreamList);
+  const { year, month, handleYear, handleMonth } = useYearMonth();
+  const [dreamList, setDreamList] = useState(initialDreamList);
+
+  return (
+    <>
+      <DateSelector year={year} month={month} handleMonth={handleMonth} handleYear={handleYear} />
+      <DreamList dreamList={dreamList} />
+    </>
+  );
+}

--- a/src/app/(protected)/(main)/_components/UserGreeting.tsx
+++ b/src/app/(protected)/(main)/_components/UserGreeting.tsx
@@ -1,11 +1,18 @@
 "use client";
 
+// library
 import { useState } from "react";
 
-import { userInfoMock } from "@/mocks/user.mock";
+// types
+import { Profile } from "@/types";
 
-export default function UserGreeting() {
+interface UserGreetingProps {
+  profile: Profile;
+}
+
+export default function UserGreeting({ profile }: UserGreetingProps) {
   const [isOpen, setIsOpen] = useState(false);
+
   const handleClick = () => {
     setIsOpen((prev) => !prev);
   };
@@ -14,20 +21,15 @@ export default function UserGreeting() {
     <div
       className={`text-h3 flex flex-col items-center justify-center gap-3 overflow-hidden text-white transition-all duration-300 ease-in-out ${isOpen ? "h-[200px]" : "h-[600px]"} `}
     >
-      <p>안녕하세요, {userInfoMock.username} 님!</p>
+      <p>안녕하세요, {profile.nickname} 님!</p>
       <button onClick={handleClick}>Click!</button>
       <p
         className={`text-base transition-all duration-1000 ease-in-out ${isOpen ? "text-black opacity-0" : "text-white"} `}
       >
-        오늘도 행복한 하루 보내시길 바랍니다.
+        {!!profile.totalCount
+          ? `${profile.totalCount + 1}번째 꿈을 작성하세요.`
+          : `첫번째 꿈을 작성해주세요.`}
       </p>
-    </div>
-  );
-
-  return (
-    <div className={"text-h3 flex h-[200px] flex-col items-center justify-center gap-3 text-white"}>
-      <p>안녕하세요, {userInfoMock.username} 님!</p>
-      <button onClick={handleClick}>클릭하기</button>
     </div>
   );
 }

--- a/src/app/(protected)/(main)/page.tsx
+++ b/src/app/(protected)/(main)/page.tsx
@@ -1,44 +1,25 @@
-"use client";
-
-// library
-import { useState } from "react";
-
 // component
 import BottomSheetLayout from "@/components/layout/BottomSheetLayout";
 import UserGreeting from "./_components/UserGreeting";
-import DateSelector from "./_components/DateSelector";
-import DreamList from "./_components/DreamList";
+import MainClientComponent from "./_components/MainClientComponent";
+import { getMyProfileServer, getMyDreamListServer } from "@/lib/api/queries";
 
-// constant
-import { MIN_YEAR } from "@/constants/dream.constants";
+export default async function MainPage() {
+  // 유저 정보 가져오기
+  const profileRes = await getMyProfileServer();
+  const profile = profileRes.data;
 
-// type
-import { Dream } from "@/types/dream";
-
-// mock
-import { myDreamListMock } from "@/mocks/dream.mock";
-
-export default function MainPage() {
-  // :TODO 여기 그냥 상위에서 로직 담당하는 걸로!
-  const current = new Date();
-  const [dreams, setDreams] = useState<Dream[]>(myDreamListMock);
-  const [year, setYear] = useState(current.getFullYear());
-  const [month, setMonth] = useState(current.getMonth() + 1);
-
-  const handleYear = (number: number) => {
-    setYear((prev) => Math.max(prev + number, MIN_YEAR));
-  };
-
-  const handleMonth = (number: number) => {
-    setMonth(number);
-  };
-
+  // 꿈 목록 가져오기
+  const dreamListRes = await getMyDreamListServer(
+    new Date().getFullYear(),
+    new Date().getMonth() + 1,
+  );
+  const initialDreamList = dreamListRes.data;
   return (
     <>
-      <UserGreeting />
+      <UserGreeting profile={profile} />
       <BottomSheetLayout>
-        <DateSelector year={year} month={month} handleMonth={handleMonth} handleYear={handleYear} />
-        <DreamList dreams={dreams} />
+        <MainClientComponent initialDreamList={initialDreamList} />
       </BottomSheetLayout>
     </>
   );

--- a/src/hooks/useYearMonth.tsx
+++ b/src/hooks/useYearMonth.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+// library
+import { useState } from "react";
+
+// constant
+import { MIN_YEAR } from "@/constants/dream.constants";
+
+export function useYearMonth() {
+  const current = new Date();
+  const [year, setYear] = useState(current.getFullYear());
+  const [month, setMonth] = useState(current.getMonth() + 1);
+
+  const handleYear = (number: number) => {
+    setYear((prev) => Math.max(prev + number, MIN_YEAR));
+  };
+
+  const handleMonth = (number: number) => {
+    setMonth(number);
+  };
+
+  return { year, month, handleYear, handleMonth };
+}


### PR DESCRIPTION
## main 페이지 API 연동
### 변경 사항 상세 내용
기존 목(Mock) 데이터로 구현된 메인 페이지를 실제 API 연동 기반으로 전환하고, 코드 구조 개선을 위한 리팩토링을 진행했습니다. 주요 변경 내용은 다음과 같습니다.

- `(main)/page.tsx`

페이지를 서버 컴포넌트로 유지하기 위해, 해당 페이지에서 초기 렌더링에 필요한 initialData를 직접 Fetch하고 하위 클라이언트 컴포넌트에 Props로 전달하도록 로직을 수정했습니다.

클라이언트 측 상태(State)를 공유하는 컴포넌트들을 `MainClientComponent.tsx` 파일로 통합하여 관리하도록 구조를 분리했습니다.

- `(main)/_component/UserGreeting.tsx`

버튼을 클릭하면 컴포넌트의 크기가 변하는 효과를 추가하였습니다.

API 연동에 맞춰 컴포넌트에서 사용하는 데이터 Type을 실제 API 응답 구조에 맞게 변경 및 적용했습니다.

- `(main)/_component/DreamList.tsx`

컴포넌트 구조의 단순화를 위해(구조 평탄화), DreamList.tsx와 개별 목록 아이템 컴포넌트인 DreamItem.tsx가 동일한 레벨에 위치하도록 파일 구조를 수정했습니다.

- `src/hooks/useYearMonth.tsx`

사용자가 선택한 연도와 월을 관리하는 useYearMonth를 커스텀 훅으로 분리하였습니다.



