### PR TITLE
코드 포맷팅 및 square 페이지 무한스크롤 적용

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,7 +3,8 @@
 /** @type {import('prettier').Config & import('prettier-plugin-tailwindcss').PluginOptions} */
 export default {
   plugins: ["prettier-plugin-tailwindcss"],
-  tailwindStylesheet: "./app/globals.css",
+  tailwindAttributes: ["className"],
+  tailwindStylesheet: "./src/app/globals.css",
   printWidth: 100,
   tabWidth: 2,
 };

--- a/src/app/(protected)/(main)/_components/DreamItem.tsx
+++ b/src/app/(protected)/(main)/_components/DreamItem.tsx
@@ -24,7 +24,7 @@ export default function DreamItem({ dream, handleClick }: DreamItemProps) {
       <div className="relative flex h-[80px] flex-1 items-center p-2 text-white">
         <p className="z-2 line-clamp-2">{dream.content}</p>
         <div
-          className={`z-1 absolute inset-0 rounded-lg bg-black ${dream.image ? "opacity-30" : "opacity-80"}`}
+          className={`absolute inset-0 z-1 rounded-lg bg-black ${dream.image ? "opacity-30" : "opacity-80"}`}
         ></div>
         {dream.image && (
           <Image src={dream.image} alt="꿈이미지" fill className="rounded-lg object-cover" />

--- a/src/app/(protected)/(main)/_components/DreamList.tsx
+++ b/src/app/(protected)/(main)/_components/DreamList.tsx
@@ -4,10 +4,10 @@
 import DreamItem from "./DreamItem";
 
 // types
-import { MyDreamList } from "@/types/dream";
+import { MyDreamSummary } from "@/types/dream";
 
 interface DreamListProps {
-  dreamList: MyDreamList;
+  dreamList: MyDreamSummary[];
 }
 
 export default function DreamList({ dreamList }: DreamListProps) {

--- a/src/app/(protected)/(main)/_components/MainClientComponent.tsx
+++ b/src/app/(protected)/(main)/_components/MainClientComponent.tsx
@@ -11,10 +11,10 @@ import DreamList from "./DreamList";
 import { useYearMonth } from "@/hooks/useYearMonth";
 
 // type
-import { MyDreamList } from "@/types/dream";
+import { MyDreamSummary } from "@/types/dream";
 
 interface MainClientComponentProps {
-  initialDreamList: MyDreamList;
+  initialDreamList: MyDreamSummary[];
 }
 
 export default function MainClientComponent({ initialDreamList }: MainClientComponentProps) {

--- a/src/app/(protected)/(main)/_components/UserGreeting.tsx
+++ b/src/app/(protected)/(main)/_components/UserGreeting.tsx
@@ -19,7 +19,7 @@ export default function UserGreeting({ profile }: UserGreetingProps) {
 
   return (
     <div
-      className={`text-h3 flex flex-col items-center justify-center gap-3 overflow-hidden text-white transition-all duration-300 ease-in-out ${isOpen ? "h-[200px]" : "h-[600px]"} `}
+      className={`flex flex-col items-center justify-center gap-3 overflow-hidden text-h3 text-white transition-all duration-300 ease-in-out ${isOpen ? "h-[200px]" : "h-[600px]"} `}
     >
       <p>안녕하세요, {profile.nickname} 님!</p>
       <button onClick={handleClick}>Click!</button>

--- a/src/app/(protected)/dream/_components/ContentEditor.tsx
+++ b/src/app/(protected)/dream/_components/ContentEditor.tsx
@@ -25,7 +25,7 @@ export default function ContentEditor({ value, onChange }: ContentEditorProps) {
         className={`h-full w-full resize-none p-3 placeholder:text-slate-200`}
         placeholder="꿈 내용을 입력해주세요."
       />
-      <p className="absolute bottom-5 right-2 text-slate-500">
+      <p className="absolute right-2 bottom-5 text-slate-500">
         {value.length}/{MAX_LENGTH}
       </p>
     </div>

--- a/src/app/(protected)/dream/_components/ImageGenerator.tsx
+++ b/src/app/(protected)/dream/_components/ImageGenerator.tsx
@@ -92,7 +92,7 @@ function RenderButton({ disabled, handleClick }: RenderButtonProps) {
       type="button"
       onClick={handleClick}
       disabled={disabled}
-      className="p-md gap-y-md flex h-[200px] shrink-0 flex-col items-center justify-center rounded rounded-md"
+      className="flex h-[200px] shrink-0 flex-col items-center justify-center gap-y-md rounded rounded-md p-md"
     >
       <NextImage src={"/palette.png"} alt="이미지 생성 아이콘" width={80} height={80} />
       <p>꿈 이미지 생성하기</p>
@@ -112,10 +112,10 @@ interface RenderInterpProps {
 
 function RenderImage({ value, handleClick }: RenderInterpProps) {
   return (
-    <div className="aspect-1/1 relative w-full bg-black/20">
+    <div className="relative aspect-1/1 w-full bg-black/20">
       <NextImage src={value!} alt="AI로 생성된 이미지" fill className="object-cover" />
       <button
-        className="aspect-sqaure absolute right-2 top-2 w-[30px] rounded-full bg-black/40"
+        className="aspect-sqaure absolute top-2 right-2 w-[30px] rounded-full bg-black/40"
         onClick={handleClick} // 이미지 숨기기 및 초기 상태로 복귀
       >
         X
@@ -130,8 +130,8 @@ function RenderImage({ value, handleClick }: RenderInterpProps) {
  */
 function RenderLoading() {
   return (
-    <div className="gap-y-lg p-lg flex h-40 flex-col items-center justify-center rounded-lg bg-black/20">
-      <div className="border-primary h-8 w-8 animate-spin rounded-full border-4 border-t-transparent" />
+    <div className="flex h-40 flex-col items-center justify-center gap-y-lg rounded-lg bg-black/20 p-lg">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
       <p>이미지를 생성하고 있습니다.</p>
     </div>
   );

--- a/src/app/(protected)/dream/_components/InterpGenerator.tsx
+++ b/src/app/(protected)/dream/_components/InterpGenerator.tsx
@@ -109,7 +109,7 @@ interface RenderInterpProps {
  */
 function RenderInterp({ value, handleClick }: RenderInterpProps) {
   return (
-    <div className="p-lg flex flex-col items-center space-y-4 rounded-lg bg-black/20">
+    <div className="flex flex-col items-center space-y-4 rounded-lg bg-black/20 p-lg">
       <p className="text-h4 font-bold">해몽 결과</p>
       <p>{value}</p>
       <Button
@@ -132,8 +132,8 @@ function RenderInterp({ value, handleClick }: RenderInterpProps) {
  */
 function RenderLoading() {
   return (
-    <div className="gap-y-lg p-lg flex h-40 flex-col items-center justify-center rounded-lg bg-black/20">
-      <div className="border-primary h-8 w-8 animate-spin rounded-full border-4 border-t-transparent" />
+    <div className="flex h-40 flex-col items-center justify-center gap-y-lg rounded-lg bg-black/20 p-lg">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
       <p>꿈을 분석하는 중입니다.</p>
     </div>
   );

--- a/src/app/(protected)/dream/_components/MyDreamClientComponent.tsx
+++ b/src/app/(protected)/dream/_components/MyDreamClientComponent.tsx
@@ -43,7 +43,7 @@ export default function MyDreamClientComponent({ initialData }: MyDreamClientCom
   };
 
   return (
-    <form onSubmit={handleSubmit} className="gap-y-md flex flex-col">
+    <form onSubmit={handleSubmit} className="flex flex-col gap-y-md">
       <DatePicker value={dream.writeTime} onChange={(value) => updateField("writeTime", value)} />
       <ContentEditor value={dream.content} onChange={(value) => updateField("content", value)} />
       <InterpGenerator
@@ -57,7 +57,7 @@ export default function MyDreamClientComponent({ initialData }: MyDreamClientCom
         getFormData={getFormData}
       />
       <ShareToggleBox value={dream.isShared} onChange={(value) => updateField("isShared", value)} />
-      <Button variant="primary" size="md" className="p-md mx-auto" rounded="md" type="submit">
+      <Button variant="primary" size="md" className="mx-auto p-md" rounded="md" type="submit">
         저장하기
       </Button>
     </form>

--- a/src/app/(protected)/dream/layout.tsx
+++ b/src/app/(protected)/dream/layout.tsx
@@ -1,12 +1,11 @@
-
 export default function DreamLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <div className="hide-scrollbar flex flex-col flex-1 min-h-0 gap-y-md overflow-y-scroll text-white p-md">
+    <div className="hide-scrollbar flex min-h-0 flex-1 flex-col gap-y-md overflow-y-scroll p-md text-white">
       {children}
     </div>
-  )
+  );
 }

--- a/src/app/(protected)/settings/_components/SettingsOption.tsx
+++ b/src/app/(protected)/settings/_components/SettingsOption.tsx
@@ -9,7 +9,7 @@ interface SettingsOptionProps {
 export default function SettingsOption({ label, icon: Icon, handleClick }: SettingsOptionProps) {
   return (
     <div
-      className="p-lg active:bg-secondary/20 flex items-center justify-between"
+      className="flex items-center justify-between p-lg active:bg-secondary/20"
       onClick={handleClick}
     >
       <p>{label}</p>

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -19,7 +19,7 @@ export default function SettingsPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="text-bold text-h3 flex h-[150px] items-center justify-center font-bold text-white">
+      <div className="text-bold flex h-[150px] items-center justify-center text-h3 font-bold text-white">
         <p>환경 설정</p>
       </div>
       <BottomSheetLayout>

--- a/src/app/(protected)/square/[dreamId]/_components/CommentInput.tsx
+++ b/src/app/(protected)/square/[dreamId]/_components/CommentInput.tsx
@@ -21,36 +21,40 @@ export default function CommentInput({ onAddComment }: CommentInputProps) {
     e.preventDefault();
     const trimmedText = commentText.trim();
     if (!trimmedText) return;
-    console.log("제출!!")
+    console.log("제출!!");
     onAddComment(trimmedText);
     setCommentText("");
   };
 
   return (
-    <form onSubmit={(e) => {
-      console.log("이벤트 발생")
-      handleSubmit(e)
-    }
-    } className="flex h-fit items-center gap-x-3">
+    <form
+      onSubmit={(e) => {
+        console.log("이벤트 발생");
+        handleSubmit(e);
+      }}
+      className="flex h-fit items-center gap-x-3"
+    >
       {/* 사용자 이미지 */}
       {/* <img
         src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e"
         className="aspect-square h-10 rounded-full"
       /> */}
-      <input value={commentText}  onChange={(e) => setCommentText(e.target.value)} placeholder="댓글을 입력하세요." className="flex-1" />
+      <input
+        value={commentText}
+        onChange={(e) => setCommentText(e.target.value)}
+        placeholder="댓글을 입력하세요."
+        className="flex-1"
+      />
       <button
         type="submit"
         disabled={!commentText.trim()}
-        className="hover:bg-primary/10 aspect-square rounded-full p-3"
+        className="aspect-square rounded-full p-3 hover:bg-primary/10"
       >
         <IoMdCheckmark />
       </button>
     </form>
   );
 }
-
-
-
 
 /**
 "use client";

--- a/src/app/(protected)/square/[dreamId]/_components/CommentItem.tsx
+++ b/src/app/(protected)/square/[dreamId]/_components/CommentItem.tsx
@@ -4,13 +4,11 @@
 import { useState } from "react";
 
 // components
-import Button from "@/components/common/Button"; // ❌ 외부 Button 대신 네이티브 버튼 사용
-import { IoMdMore, IoMdHeart, IoMdHeartEmpty } from "react-icons/io"; // ❌ react-icons 대신 인라인 SVG 사용
+import Button from "@/components/common/Button";
+import { IoMdMore, IoMdHeart, IoMdHeartEmpty } from "react-icons/io";
 
 // types
 import { SharedDreamComment } from "@/types";
-
-// --- 인라인 SVG 아이콘 정의 ---
 
 interface CommentItemProps {
   comment: SharedDreamComment;

--- a/src/app/(protected)/square/[dreamId]/_components/CommentItem.tsx
+++ b/src/app/(protected)/square/[dreamId]/_components/CommentItem.tsx
@@ -33,22 +33,20 @@ export default function CommentItem({ comment }: CommentItemProps) {
     setActiveMenu((prev) => !prev);
   };
 
-  const handleDelete = (commentId: number) => {
-
-  }
+  const handleDelete = (commentId: number) => {};
   return (
-    <div key={comment.commentId} className="relative flex gap-x-3 shrink-0">
+    <div key={comment.commentId} className="relative flex shrink-0 gap-x-3">
       {/* <img
         src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e"
         className="aspect-square h-10 rounded-full"
       /> */}
-      <div className="space-y-sm flex-1">
+      <div className="flex-1 space-y-sm">
         <p className="font-semibold">{comment.nickname}</p>
         <p className="flex-1">
           {comment.content} {comment.content}
         </p>
       </div>
-      <button onClick={handleLike} className="pt-md h-fit">
+      <button onClick={handleLike} className="h-fit pt-md">
         {isLiked ? (
           <IoMdHeart size={20} className="text-red-700/80" />
         ) : (
@@ -59,16 +57,18 @@ export default function CommentItem({ comment }: CommentItemProps) {
         size="none"
         variant="none"
         rounded="full"
-        className="hover:bg-primary/10 aspect-square h-10 p-1"
+        className="aspect-square h-10 p-1 hover:bg-primary/10"
         onClick={toggleMenu}
       >
         <IoMdMore size={30} className="text-secondary" />
       </Button>
       {/* Action Sheet / Dropdown */}
       {activeMenu && (
-        <div className="border-secondary absolute right-[40px] top-0 z-50 mt-2 w-40 rounded-lg border bg-white shadow-lg">
-          <button className="w-full rounded-lg px-4 py-2 text-left hover:bg-gray-100" onClick={() => 
-            handleDelete(comment.commentId)}>
+        <div className="absolute top-0 right-[40px] z-50 mt-2 w-40 rounded-lg border border-secondary bg-white shadow-lg">
+          <button
+            className="w-full rounded-lg px-4 py-2 text-left hover:bg-gray-100"
+            onClick={() => handleDelete(comment.commentId)}
+          >
             삭제
           </button>
           {/* <button className="w-full rounded-b-lg px-4 py-2 text-left hover:bg-gray-100">

--- a/src/app/(protected)/square/[dreamId]/_components/CommentList.tsx
+++ b/src/app/(protected)/square/[dreamId]/_components/CommentList.tsx
@@ -16,14 +16,16 @@ interface CommentListProps {
 export default function CommentList({ commentList }: CommentListProps) {
   if (!commentList || commentList.length === 0) {
     return (
-      <p className="flex-1 flex flex-col justify-center itmes-center text-center text-gray-500">아직 댓글이 없습니다. 첫 댓글을 남겨보세요!</p>
+      <p className="itmes-center flex flex-1 flex-col justify-center text-center text-gray-500">
+        아직 댓글이 없습니다. 첫 댓글을 남겨보세요!
+      </p>
     );
   }
   return (
-    <div className="hide-scrollbar flex flex-col flex-1 min-h-0 gap-y-md overflow-y-scroll">
+    <div className="hide-scrollbar flex min-h-0 flex-1 flex-col gap-y-md overflow-y-scroll">
       {commentList.map((comment) => (
         <CommentItem key={comment.commentId} comment={comment} />
       ))}
     </div>
-  )
+  );
 }

--- a/src/app/(protected)/square/[dreamId]/_components/CommentSection.tsx
+++ b/src/app/(protected)/square/[dreamId]/_components/CommentSection.tsx
@@ -37,11 +37,10 @@ export default function CommentSection({ initialCommentList }: CommentSectionPro
 
     console.log("새 댓글 전송 (API 호출 필요):", newContent);
     // 로직 연결 전이기 때문에 우선은 상태를 업데이트하여 목록 맨 아래에 새 댓글 추가
-    setComments((prevComments) => [ newComment, ...prevComments]);
-
+    setComments((prevComments) => [newComment, ...prevComments]);
   };
 
-  const handleDeleteComment = () => {}
+  const handleDeleteComment = () => {};
   return (
     <>
       {/* 1. 댓글 목록 영역 (스크롤 가능) - 상태를 전달 */}

--- a/src/app/(protected)/square/[dreamId]/_components/SharedDreamContent.tsx
+++ b/src/app/(protected)/square/[dreamId]/_components/SharedDreamContent.tsx
@@ -12,7 +12,7 @@ import { SharedDreamDetail } from "@/types";
 
 interface SharedDreamContentProps {
   dream: SharedDreamDetail;
-};
+}
 
 export default function SharedDreamContent({ dream }: SharedDreamContentProps) {
   const [isInterpShown, setIsInterpShown] = useState(false);
@@ -23,7 +23,7 @@ export default function SharedDreamContent({ dream }: SharedDreamContentProps) {
   return (
     <div className="flex flex-col items-center gap-y-md">
       <Image
-        // TODO: 이 부분 해결 필요하다! 
+        // TODO: 이 부분 해결 필요하다!
         src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e"
         alt="꿈 이미지"
         width={200}
@@ -31,7 +31,7 @@ export default function SharedDreamContent({ dream }: SharedDreamContentProps) {
         className="aspect-square rounded-lg"
       />
       {isInterpShown ? (
-        <div className="bg-secondary/50 gap-y-sm p-md flex w-full flex-col rounded-lg">
+        <div className="flex w-full flex-col gap-y-sm rounded-lg bg-secondary/50 p-md">
           <p className="text-center">꿈 내용</p>
           <p className="hide-scroller max-h-[100px] overflow-y-scroll break-all">{dream.content}</p>
           <hr className="border-secondary" />
@@ -43,10 +43,9 @@ export default function SharedDreamContent({ dream }: SharedDreamContentProps) {
         </div>
       ) : (
         <Button size="full" variant="primary" rounded="md" onClick={handleClick}>
-          <p className="text-body-md p-md">💡 어떤 꿈인지 궁금하다면 클릭해보세요!</p>
+          <p className="p-md text-body-md">💡 어떤 꿈인지 궁금하다면 클릭해보세요!</p>
         </Button>
       )}
     </div>
-  )
-
+  );
 }

--- a/src/app/(protected)/square/[dreamId]/page.tsx
+++ b/src/app/(protected)/square/[dreamId]/page.tsx
@@ -18,7 +18,7 @@ export default async function SquareDetail({ params }: SquareDetailProps) {
   const sharedDream = sharedDreamRes.data;
   const initialCommentList = sharedDream.commentList;
   return (
-    <div className="gap-y-lg flex min-h-0 flex-1 flex-col bg-black/30">
+    <div className="flex min-h-0 flex-1 flex-col gap-y-lg bg-black/30">
       <HeaderBar />
       <SharedDreamContent dream={sharedDream} />
       <BottomSheetLayout>

--- a/src/app/(protected)/square/_components/LoadingSpinner.tsx
+++ b/src/app/(protected)/square/_components/LoadingSpinner.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function LoadingSpinner() {
+  return (
+    <div className="flex h-[100px] flex-col items-center justify-center">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+    </div>
+  );
+}

--- a/src/app/(protected)/square/_components/SharedDreamCard.tsx
+++ b/src/app/(protected)/square/_components/SharedDreamCard.tsx
@@ -1,26 +1,39 @@
 "use client";
 
-// component
+import React, { forwardRef } from "react";
 import Link from "next/link";
 import Image from "next/image";
 
 // type
 import { SharedDreamSummary } from "@/types";
 
-interface SharedDreamCardProps {
+// Link 컴포넌트가 가지는 기본 props들을 모두 포함하도록 확장합니다.
+interface SharedDreamCardProps extends React.ComponentPropsWithoutRef<typeof Link> {
   dream: SharedDreamSummary;
 }
 
-export default function SharedDreamCard({ dream }: SharedDreamCardProps) {
-  return (
-    <Link
-      key={`dream-${dream.dreamId}`}
-      href={`/square/${dream.dreamId}`}
-      className="relative aspect-square w-full"
-    >
-      <Image src={dream.image || ""} alt={`image-${dream.dreamId}`} fill />
-    </Link>
-  );
-}
+// forwardRef를 사용하여 ref를 부모로부터 전달받습니다.
+const SharedDreamCard = forwardRef<HTMLElement, SharedDreamCardProps>(
+  ({ dream, className, ...props }, ref) => {
+    return (
+      <Link
+        {...props} // 나머지 props(href 등)를 Link에 전달
+        ref={ref as React.Ref<HTMLAnchorElement>} // 전달받은 ref를 Link(anchor 태그)에 연결
+        // 기존 스타일과 외부에서 들어온 className을 합쳐줍니다. (tailwind-merge 사용 권장)
+        className={`relative aspect-square w-full overflow-hidden ${className || ""}`}
+      >
+        <Image
+          src={dream.image || "/default-image.png"} // 이미지가 없을 때의 대비책
+          alt={`dream-image-${dream.dreamId}`}
+          fill
+          className="object-cover" // 이미지가 비율에 맞게 꽉 차도록 설정
+        />
+      </Link>
+    );
+  },
+);
 
-// TODO: Next.js의 Image 컴포넌트의 fill은 부모 기준으로 적용 => relative 필요
+// 디버깅 시 컴포넌트 이름을 식별하기 위해 설정합니다.
+SharedDreamCard.displayName = "SharedDreamCard";
+
+export default SharedDreamCard;

--- a/src/app/(protected)/square/_components/SharedDreamList.tsx
+++ b/src/app/(protected)/square/_components/SharedDreamList.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+// library
+import { useState } from "react";
+
+// components
+import SharedDreamCard from "./SharedDreamCard";
+import LoadingSpinner from "./LoadingSpinner";
+
+// hooks
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
+
+// types
+import { SharedDreamSummary } from "@/types";
+
+interface SharedDreamListProps {
+  initialData: SharedDreamSummary[];
+}
+
+export default function SharedDreamList({ initialData }: SharedDreamListProps) {
+  const [dreamList, setDreamList] = useState(initialData);
+  const [loading, setLoading] = useState(false);
+  const [hasNextPage, setHasNextPage] = useState(true);
+
+  // 데이터를 더 가져오는 로직
+  const fetchMoreDreams = async () => {
+    if (loading) return;
+    setLoading(true);
+
+    // API 호출(client)
+    // const nextCursor = dreamList[-1].dreamId;
+    // const nextPageData = await getSharedDreamList(nextCursor);
+    // setDreams((prev) => [...prev, ...nextPageData]);
+    // setLoading(false);
+  };
+
+  // 훅 사용
+  const { targetRef } = useInfiniteScroll({
+    fetchNextPage: fetchMoreDreams,
+    hasNextPage: hasNextPage,
+    threshold: 0.1,
+  });
+
+  return (
+    <>
+      <div className="grid grid-cols-3 gap-sm">
+        {dreamList.map((dream, idx) => {
+          const isLastItem = idx === dreamList.length - 1;
+          return (
+            <SharedDreamCard
+              href={`/square/${dream.dreamId}`}
+              dream={dream}
+              key={dream.dreamId}
+              ref={isLastItem ? targetRef : null}
+            />
+          );
+        })}
+      </div>
+      {loading && <LoadingSpinner />}
+    </>
+  );
+}

--- a/src/app/(protected)/square/page.tsx
+++ b/src/app/(protected)/square/page.tsx
@@ -2,17 +2,15 @@
 import { getSharedDreamListServer } from "@/lib/api/queries";
 
 // components
-import SharedDreamCard from "./_components/SharedDreamCard";
+import SharedDreamList from "./_components/SharedDreamList";
 
 export default async function SharedDreamFeedPage() {
-  const sharedDreamListRes = await getSharedDreamListServer();
-  const sharedDreamList = sharedDreamListRes.data;
+  const res = await getSharedDreamListServer();
+  const initialDreamList = res.data;
 
   return (
-    <div className="hide-scrollbar px-lg pt-2xl gap-sm grid flex-1 grid-cols-3 overflow-y-scroll bg-black/10">
-      {sharedDreamList.map((dream) => (
-        <SharedDreamCard dream={dream} key={dream.dreamId} />
-      ))}
+    <div className="hide-scrollbar flex-1 overflow-y-scroll bg-black/10 px-lg pt-2xl">
+      <SharedDreamList initialData={initialDreamList} />
     </div>
   );
 }

--- a/src/app/(protected)/stream/[streamId]/page.tsx
+++ b/src/app/(protected)/stream/[streamId]/page.tsx
@@ -4,7 +4,7 @@ import BottomSheetLayout from "@/components/layout/BottomSheetLayout";
 
 export default function StreamDetailPage() {
   return (
-    <div className="py-sm flex h-full flex-col bg-black text-white">
+    <div className="flex h-full flex-col bg-black py-sm text-white">
       {/* 상단 헤더 */}
       <HeaderBar />
       {/* 영상 영역 */}
@@ -16,16 +16,16 @@ export default function StreamDetailPage() {
           className="object-cover opacity-90"
         />
         {/* Live Badge */}
-        <div className="py-sm px-md absolute left-2 top-2 rounded-md bg-red-600 text-[12px] text-white">
+        <div className="absolute top-2 left-2 rounded-md bg-red-600 px-md py-sm text-[12px] text-white">
           ● LIVE
         </div>
         {/* 시청자 수 */}
-        <div className="py-sm px-md absolute right-2 top-2 rounded-md bg-black/60 text-[12px] text-white">
+        <div className="absolute top-2 right-2 rounded-md bg-black/60 px-md py-sm text-[12px] text-white">
           0명 시청중
         </div>
       </div>
       {/* 영상 제목 및 정보 */}
-      <div className="px-md py-sm space-y-[4px]">
+      <div className="space-y-[4px] px-md py-sm">
         <h1 className="line-clamp-2 text-[16px] font-semibold">
           이것은 음악방송 테스트입니다. 이것은 음악방송 테스트입니다.
         </h1>
@@ -57,7 +57,7 @@ export default function StreamDetailPage() {
       <BottomSheetLayout isDarkMode={true} className="flex flex-1 px-0 py-0">
         <div className="flex h-full flex-col">
           {/* 채팅 메시지 리스트 */}
-          <div className="hide-scrollbar px-md py-md space-y-md border-1 flex-1 overflow-y-scroll border-t border-white/30">
+          <div className="hide-scrollbar flex-1 space-y-md overflow-y-scroll border-1 border-t border-white/30 px-md py-md">
             {Array.from({ length: 60 }).map((_, idx) => (
               <div key={idx} className={`${(idx * 3) % 7 > 2 ? "text-right" : "text-left"}`}>
                 <p className="text-[13px] font-semibold">별명</p>
@@ -66,13 +66,13 @@ export default function StreamDetailPage() {
             ))}
           </div>
           {/* 채팅 입력창 */}
-          <div className="p-md border-1 border-t border-white/30">
+          <div className="border-1 border-t border-white/30 p-md">
             <div className="flex items-center gap-x-[10px]">
               <textarea
                 placeholder="메시지 입력..."
                 className="h-[40px] flex-1 resize-none rounded-lg px-[12px] py-[10px] text-[14px] leading-[1.2] text-white placeholder-gray-400"
               />
-              <button className="text-primary text-[14px] font-semibold">보내기</button>
+              <button className="text-[14px] font-semibold text-primary">보내기</button>
             </div>
           </div>
         </div>

--- a/src/app/(protected)/stream/page.tsx
+++ b/src/app/(protected)/stream/page.tsx
@@ -17,7 +17,7 @@ export default function StreamPage() {
             />
 
             {/* 시청자 수 배지 */}
-            <span className="p-md absolute bottom-2 right-2 rounded-md bg-black/70 text-[12px] text-white">
+            <span className="absolute right-2 bottom-2 rounded-md bg-black/70 p-md text-[12px] text-white">
               🔴 3명 시청중
             </span>
           </div>

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -5,10 +5,10 @@ import OAuthList from "./_components/OAuthList";
 export default function LoginPage() {
   return (
     <AuthGuard mode="public">
-      <div className="p-2xl flex h-full w-full flex-col">
-        <div className="gap-lg flex flex-1 flex-col items-end justify-center font-bold text-white">
+      <div className="flex h-full w-full flex-col p-2xl">
+        <div className="flex flex-1 flex-col items-end justify-center gap-lg font-bold text-white">
           <h1 className="text-h1">DREA-MONG</h1>
-          <div className="gap-md flex flex-col items-end justify-center">
+          <div className="flex flex-col items-end justify-center gap-md">
             <p className="text-subtitle">꿈의 비밀을 통해</p>
             <p className="text-subtitle">자신을 발견해보세요.</p>
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
       </head>
       <body>
         <div className="h-full w-full bg-slate-500">
-          <div className="mx-auto flex h-full min-h-[600px] w-full min-w-[300px] max-w-[500px] flex-col bg-[url(/background.svg)] bg-cover bg-center">
+          <div className="mx-auto flex h-full min-h-[600px] w-full max-w-[500px] min-w-[300px] flex-col bg-[url(/background.svg)] bg-cover bg-center">
             {children}
           </div>
         </div>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -4,7 +4,7 @@ import Button from "@/components/common/Button";
 
 export default function NotFound() {
   return (
-    <div className="p-lg gap-y-xl flex h-full flex-col items-center justify-center">
+    <div className="flex h-full flex-col items-center justify-center gap-y-xl p-lg">
       <Image src="/404.png" alt="404" width={400} height={400} />
       <p className="text-h1 font-bold text-white">NOT FOUND</p>
       <Link href="/" className="flex w-full justify-center">

--- a/src/components/common/ToggleButton.tsx
+++ b/src/components/common/ToggleButton.tsx
@@ -24,7 +24,7 @@ export default function ToggleButton({ name, checked, onChange }: ToggleButtonPr
       >
         {/* 토글 썸 */}
         <span
-          className={`absolute left-1 top-1 h-4 w-4 rounded-full border border-black/10 bg-white transition-transform ${checked ? "translate-x-4" : ""} `}
+          className={`absolute top-1 left-1 h-4 w-4 rounded-full border border-black/10 bg-white transition-transform ${checked ? "translate-x-4" : ""} `}
         />
       </span>
     </label>

--- a/src/components/layout/BottomSheetLayout.tsx
+++ b/src/components/layout/BottomSheetLayout.tsx
@@ -16,7 +16,7 @@ export default function BottomSheetLayout({
 }: BottomSheetLayoutProps) {
   return (
     <div
-      className={`p-lg gap-md flex min-h-0 flex-1 flex-col rounded-t-xl ${
+      className={`flex min-h-0 flex-1 flex-col gap-md rounded-t-xl p-lg ${
         isDarkMode ? "bg-gray-800 text-white" : "bg-white"
       } ${className ?? ""}`}
       {...rest}

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,52 @@
+import { useRef, useCallback, useEffect } from "react";
+
+interface UseInfiniteScrollProps {
+  fetchNextPage: () => void;
+  threshold?: number;
+  hasNextPage: boolean;
+}
+
+/**
+ * @hooks useInfiniteScroll
+ * @param fetchNextPage: fetch 함수
+ * @param threshold: 스크롤 감지할 임계점(0 ~ 1)
+ * @param hasNextPage: 추가 로딩 가능 상태 확인
+ * @return targetRef
+ */
+export function useInfiniteScroll({
+  fetchNextPage,
+  threshold,
+  hasNextPage,
+}: UseInfiniteScrollProps) {
+  const targetRef = useRef<HTMLElement | null>(null);
+
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const [entry] = entries;
+
+      // 타겟이 화면에 보이고(isIntersecting), 다음 페이지가 있을 때만 fetch
+      if (entry.isIntersecting && hasNextPage) {
+        fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage],
+  );
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target) return;
+
+    // 1. Observer 생성
+    const observer = new IntersectionObserver(handleObserver, {
+      threshold,
+    });
+
+    // 2. 타겟 관찰 시작
+    observer.observe(target);
+
+    // 3. 언마운트 시 관찰 중단
+    return () => observer.unobserve(target);
+  }, [handleObserver, threshold]);
+
+  return { targetRef };
+}

--- a/src/lib/api/endpoints.ts
+++ b/src/lib/api/endpoints.ts
@@ -13,15 +13,15 @@ export const GET_MY_PROFILE = () => `/users/me`;
 export const PATCH_NICKNAME = () => `/users/me/nickname`;
 
 // Dream
-export const GET_MY_DREAM_LIST = () => `/dreams`;
-export const CREATE_DREAM = () => `/dreams`;
-export const GET_MY_DREAM_DETAIL = (dreamId: number) => `/dreams/${dreamId}`;
-export const UPDATE_DREAM = (dreamId: number) => `/dreams/${dreamId}`;
-export const DELETE_DREAM = (dreamId: number) => `/dreams/${dreamId}`;
+export const GET_MY_DREAM_LIST = () => `/dreams/me`;
+export const CREATE_DREAM = () => `/dreams/me`;
+export const GET_MY_DREAM_DETAIL = (dreamId: number) => `/dreams/me/${dreamId}`;
+export const UPDATE_DREAM = (dreamId: number) => `/dreams/me/${dreamId}`;
+export const DELETE_DREAM = (dreamId: number) => `/dreams/me/${dreamId}`;
 
 // AI Functions
-export const GENERATE_IMAGE = () => `/dreams/image`;
-export const GENERATE_INTERPRETATION = () => `/dreams/interpretation`;
+export const GENERATE_IMAGE = () => `/dreams/me/image`;
+export const GENERATE_INTERPRETATION = () => `/dreams/me/interpretation`;
 
 // Shared Dreams
 export const GET_SHARED_DREAM_LIST = () => `/dreams/shared`;

--- a/src/lib/api/endpoints.ts
+++ b/src/lib/api/endpoints.ts
@@ -24,7 +24,7 @@ export const GENERATE_IMAGE = () => `/dreams/me/image`;
 export const GENERATE_INTERPRETATION = () => `/dreams/me/interpretation`;
 
 // Shared Dreams
-export const GET_SHARED_DREAM_LIST = () => `/dreams/shared`;
+export const GET_SHARED_DREAM_LIST = (cursor = 0) => `/dreams/shared?cursor=${cursor}`;
 export const GET_SHARED_DREAM_DETAIL = (dreamId: number) => `/dreams/shared/${dreamId}`;
 
 // Comments

--- a/src/lib/api/queries.ts
+++ b/src/lib/api/queries.ts
@@ -2,11 +2,13 @@
 // import httpClient from "./fetcher/http-client";
 import { serverFetcher } from "./fetcher/server-fetcher";
 
-import { GET_MY_PROFILE,
+import {
+  GET_MY_PROFILE,
   GET_MY_DREAM_LIST,
   GET_MY_DREAM_DETAIL,
   GET_SHARED_DREAM_LIST,
-  GET_SHARED_DREAM_DETAIL, } from "./endpoints";
+  GET_SHARED_DREAM_DETAIL,
+} from "./endpoints";
 
 // types
 import {
@@ -15,7 +17,7 @@ import {
   SharedDreamList,
   SharedDreamDetail,
   DreamId,
-  Profile
+  Profile,
 } from "@/types";
 
 // TODO: 여기에서 처리를 fetcher<Profile>로 하기보다는 fetch<ApiResponse<Profile>>이 나은가..?
@@ -25,14 +27,14 @@ import {
 /**
  * 유저 정보 조회 - 서버 전용
  */
-export async function  getMyProfileServer () {
+export async function getMyProfileServer() {
   return serverFetcher<Profile>(GET_MY_PROFILE());
 }
 /**
  * 꿈 조회 - 서버 전용
  * @params year, month
  */
-export async function  getMyDreamListServer (year: number, month: number) {
+export async function getMyDreamListServer(year: number, month: number) {
   const params = new URLSearchParams({ year: String(year), month: String(month) });
   return serverFetcher<MyDreamList>(`${GET_MY_DREAM_LIST()}?${params}`);
 }
@@ -40,20 +42,20 @@ export async function  getMyDreamListServer (year: number, month: number) {
  * 꿈 상세 조회 - 서버 전용
  * @params dreamId
  */
-export async function  getMyDreamDetailServer (dreamId: DreamId) {
+export async function getMyDreamDetailServer(dreamId: DreamId) {
   return serverFetcher<MyDreamDetail>(GET_MY_DREAM_DETAIL(dreamId));
 }
 /**
  * 공유된 꿈 목록 조회 - 서버 전용
  */
-export async function  getSharedDreamListServer () {
+export async function getSharedDreamListServer() {
   return serverFetcher<SharedDreamList>(GET_SHARED_DREAM_LIST());
 }
 /**
  * 공유된 꿈 상세 조회 - 서버 전용
  * @params dreamId
  */
-export async function  getSharedDreamDetailServer (dreamId: DreamId) {
+export async function getSharedDreamDetailServer(dreamId: DreamId) {
   return serverFetcher<SharedDreamDetail>(GET_SHARED_DREAM_DETAIL(dreamId));
 }
 

--- a/src/lib/api/queries.ts
+++ b/src/lib/api/queries.ts
@@ -13,7 +13,7 @@ import {
 // types
 import {
   MyDreamDetail,
-  SharedDreamList,
+  SharedDreamSummary,
   SharedDreamDetail,
   DreamId,
   Profile,
@@ -49,7 +49,7 @@ export async function getMyDreamDetailServer(dreamId: DreamId) {
  * 공유된 꿈 목록 조회 - 서버 전용
  */
 export async function getSharedDreamListServer() {
-  return serverFetcher<SharedDreamList>(GET_SHARED_DREAM_LIST());
+  return serverFetcher<SharedDreamSummary[]>(GET_SHARED_DREAM_LIST());
 }
 /**
  * 공유된 꿈 상세 조회 - 서버 전용

--- a/src/lib/api/queries.ts
+++ b/src/lib/api/queries.ts
@@ -13,11 +13,11 @@ import {
 // types
 import {
   MyDreamDetail,
-  MyDreamList,
   SharedDreamList,
   SharedDreamDetail,
   DreamId,
   Profile,
+  MyDreamSummary,
 } from "@/types";
 
 // TODO: 여기에서 처리를 fetcher<Profile>로 하기보다는 fetch<ApiResponse<Profile>>이 나은가..?
@@ -36,7 +36,7 @@ export async function getMyProfileServer() {
  */
 export async function getMyDreamListServer(year: number, month: number) {
   const params = new URLSearchParams({ year: String(year), month: String(month) });
-  return serverFetcher<MyDreamList>(`${GET_MY_DREAM_LIST()}?${params}`);
+  return serverFetcher<MyDreamSummary[]>(`${GET_MY_DREAM_LIST()}?${params}`);
 }
 /**
  * 꿈 상세 조회 - 서버 전용

--- a/src/types/dream.ts
+++ b/src/types/dream.ts
@@ -29,8 +29,6 @@ export type MyDreamSummary = {
   content: Content;
 };
 
-export type MyDreamList = MyDreamSummary[];
-
 export type MyDreamDetail = {
   dreamId: number | null;
   writeTime: WriteTime;

--- a/src/types/dream.ts
+++ b/src/types/dream.ts
@@ -43,8 +43,6 @@ export type SharedDreamSummary = {
   image: Image;
 };
 
-export type SharedDreamList = SharedDreamSummary[];
-
 export type SharedDreamComment = {
   commentId: number;
   content: string;
@@ -54,7 +52,7 @@ export type SharedDreamComment = {
   isLiked: boolean;
 };
 
-export type SharedDreamDetail = SharedDreamList & {
+export type SharedDreamDetail = {
   dreamId: DreamId;
   image: Image;
   content: Content;


### PR DESCRIPTION
## 코드 포맷팅 및 square 페이지 무한스크롤 적용
### 변경 사항 상세 내용
prettier-plugin-tailwind 적용을 위한 config 수정 및 square 페이지의 무한 스크롤 적용을 위한 hook과 LoadingSpinner 생성

- `hooks/useInfiniteScroll.ts`
Intersection Observer API를 활용하여 재사용 가능한 무한 스크롤(Infinite Scroll) 로직 구현  

특정 DOM 요소가 뷰포트에 노출되는 시점을 감지하여 다음 데이터를 요청, 요소가 화면에 보이더라도 `hasNextPage == true`일 때만 fetchNextPage를 호출하여 불필요한 API 요청을 방지  

useCallback을 통해 핸들러를 메모이제이션하고, 컴포넌트 언마운트 시 unobserve를 호출하여 리소스 누수를 방지  


- `/sqaure/_components/SharedDreamList.tsx`  

무한 스크롤 감지 로직을 훅으로 분리하여 관심사 분리 및 재사용성 높임.  

리스트의 마지막 아이템에만 ref를 동적으로 할당, 타겟 요소가 뷰포트에 들어올 때에 fetch 함수가 실행되도록 설계

LoadingSpinner를 배치하여 데이터를 불러오는 중임을 시작적으로 전달

해당 페이지의 경우 서비스 컨셉 상 요청의 limit이 정해져있기 때문에, cursor만 query로 전달